### PR TITLE
Add support for refreshing a resource indicator

### DIFF
--- a/lib/doorkeeper/oauth/helpers/resource_indicators_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/resource_indicators_checker.rb
@@ -3,14 +3,13 @@
 module Doorkeeper
   module OAuth
     module Helpers
-      # ResourceIndicatorsChecker validates that a proded set of indicators is valid
+      # ResourceIndicatorsChecker validates that a provided set of indicators is valid
       # for a given grant. A grant should contain the same or more grants for any provided set.
       module ResourceIndicatorsChecker
         def self.valid?(grant, requested_indicators)
           return true unless Doorkeeper.config.using_resource_indicators?
-          return true if grant.resource_indicators.empty?
 
-          requested_indicators.any? && grant.resource_indicators.contains_all?(requested_indicators)
+          grant.resource_indicators.contains_all?(requested_indicators)
         end
       end
     end

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -5,11 +5,11 @@ module Doorkeeper
     class RefreshTokenRequest < BaseRequest
       include OAuth::Helpers
 
-      validate :token_presence, error: :invalid_request
-      validate :token,        error: :invalid_grant
-      validate :client,       error: :invalid_client
-      validate :client_match, error: :invalid_grant
-      validate :scope,        error: :invalid_scope
+      validate :token_presence,      error: :invalid_request
+      validate :token,               error: :invalid_grant
+      validate :client,              error: :invalid_client
+      validate :client_match,        error: :invalid_grant
+      validate :scope,               error: :invalid_scope
       validate :resource_indicators, error: :invalid_target
 
       attr_reader :access_token, :client, :credentials, :refresh_token, :missing_param

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -174,11 +174,11 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
     end
 
     context "when resource indicators are omitted" do
-      it "issues a new token for the client" do
+      it "returns a downgraded token" do
         expect do
           request.authorize
-        end.to change { client.reload.access_tokens.count }.by(0)
-        expect(request.error).to eq(:invalid_target)
+        end.to change { client.reload.access_tokens.count }.by(1)
+        expect(client.access_tokens.last.resource_indicators).to be_empty
       end
     end
 

--- a/spec/lib/oauth/helpers/resource_indicators_checker_spec.rb
+++ b/spec/lib/oauth/helpers/resource_indicators_checker_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::OAuth::Helpers::ResourceIndicatorsChecker do
+  describe ".valid?" do
+    before do
+      allow(Doorkeeper.config).to receive(:using_resource_indicators?).and_return(true)
+    end
+
+    let(:subject) do
+      described_class.valid?(
+        double(resource_indicators: Doorkeeper::OAuth::ResourceIndicators.from_array(preapproved_indicators)),
+        Doorkeeper::OAuth::ResourceIndicators.from_array(requested_indicators),
+      )
+    end
+
+    context "when preapproved is a superset" do
+      let(:preapproved_indicators) do
+        ["http://example.com/1", "http://example.com/2"]
+      end
+
+      let(:requested_indicators) do
+        ["http://example.com/1"]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when preapproved is a subset" do
+      let(:preapproved_indicators) do
+        ["http://example.com/1"]
+      end
+
+      let(:requested_indicators) do
+        ["http://example.com/1", "http://example.com/2"]
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when preapproved is a empty" do
+      let(:preapproved_indicators) do
+        []
+      end
+
+      let(:requested_indicators) do
+        ["http://example.com/1", "http://example.com/2"]
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when both are empty " do
+      let(:preapproved_indicators) do
+        []
+      end
+
+      let(:requested_indicators) do
+        []
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when both are set and equal" do
+      let(:preapproved_indicators) do
+        ["http://example.com/1"]
+      end
+
+      let(:requested_indicators) do
+        ["http://example.com/1"]
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/support/helpers/url_helper.rb
+++ b/spec/support/helpers/url_helper.rb
@@ -10,6 +10,7 @@ module UrlHelper
       grant_type: options[:grant_type] || "authorization_code",
       code_verifier: options[:code_verifier],
       code_challenge_method: options[:code_challenge_method],
+      resource: options[:resource],
     }.reject { |_, v| v.blank? }
     "/oauth/token?#{build_query(parameters)}"
   end
@@ -48,6 +49,7 @@ module UrlHelper
       client_id: options[:client_id] || options[:client].try(:uid),
       client_secret: options[:client_secret] || options[:client].try(:secret),
       grant_type: options[:grant_type] || "refresh_token",
+      resource: options[:resource],
     }.reject { |_, v| v.blank? }
     "/oauth/token?#{build_query(parameters)}"
   end


### PR DESCRIPTION
During the previous resource indicator work, I missed the refresh token case.

This adds support for a refresh and some tests.