### PR TITLE
[OMC-89] Reapply previous PRs

### DIFF
--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -56,6 +56,7 @@ module Doorkeeper
         pre_auth.client,
         current_resource_owner,
         pre_auth.scopes,
+        pre_auth.resource_indicators,
       )
     end
 
@@ -92,7 +93,10 @@ module Doorkeeper
     end
 
     def pre_auth_params
-      params.slice(*pre_auth_param_fields).permit(*pre_auth_param_fields)
+      Doorkeeper::Helpers::ResourceIndicators.resource_identifier_from_request(
+        request,
+        params.slice(*pre_auth_param_fields).permit(*pre_auth_param_fields),
+      )
     end
 
     def pre_auth_param_fields

--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -19,6 +19,19 @@
     </div>
   <% end %>
 
+  <% if @pre_auth.resource.count > 0 %>
+    <div id="oauth-permissions">
+      <h3>Resources</h3>
+
+      <p> This application will be able to access:</p>
+      <ul class="text-info">
+        <% Array(@pre_auth.resource).each do |resource| %>
+          <li><%= resource %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
   <div class="actions">
     <%= form_tag oauth_authorization_path, method: :post do %>
       <%= hidden_field_tag :client_id, @pre_auth.client.uid, id: nil %>
@@ -29,6 +42,9 @@
       <%= hidden_field_tag :scope, @pre_auth.scope, id: nil %>
       <%= hidden_field_tag :code_challenge, @pre_auth.code_challenge, id: nil %>
       <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method, id: nil %>
+      <% @pre_auth.resource.each do |resource| %>
+        <%= hidden_field_tag "resource[]", resource, id: nil %>
+      <% end %>
       <%= submit_tag t('doorkeeper.authorizations.buttons.authorize'), class: "btn btn-success btn-lg btn-block" %>
     <% end %>
     <%= form_tag oauth_authorization_path, method: :delete do %>
@@ -40,6 +56,9 @@
       <%= hidden_field_tag :scope, @pre_auth.scope, id: nil %>
       <%= hidden_field_tag :code_challenge, @pre_auth.code_challenge, id: nil %>
       <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method, id: nil %>
+      <% @pre_auth.resource.each do |resource| %>
+        <%= hidden_field_tag "resource[]", resource %>
+      <% end %>
       <%= submit_tag t('doorkeeper.authorizations.buttons.deny'), class: "btn btn-danger btn-lg btn-block" %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,7 +117,8 @@ en:
         invalid_client: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'
         invalid_grant: 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
         unsupported_grant_type: 'The authorization grant type is not supported by the authorization server.'
-
+        invalid_target: 'The requested resource is invalid, missing, unknown, or malformed.'
+        
         invalid_token:
           revoked: "The access token was revoked"
           expired: "The access token expired"

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -22,6 +22,7 @@ module Doorkeeper
 
   module Helpers
     autoload :Controller, "doorkeeper/helpers/controller"
+    autoload :ResourceIndicators, "doorkeeper/helpers/resource_indicators"
   end
 
   module Request
@@ -56,6 +57,8 @@ module Doorkeeper
     autoload :TokenIntrospection, "doorkeeper/oauth/token_introspection"
     autoload :TokenRequest, "doorkeeper/oauth/token_request"
     autoload :TokenResponse, "doorkeeper/oauth/token_response"
+    autoload :ListLike, "doorkeeper/oauth/concerns/list_like"
+    autoload :ResourceIndicators, "doorkeeper/oauth/resource_indicators"
 
     module Authorization
       autoload :Code, "doorkeeper/oauth/authorization/code"
@@ -78,6 +81,7 @@ module Doorkeeper
       autoload :ScopeChecker, "doorkeeper/oauth/helpers/scope_checker"
       autoload :URIChecker, "doorkeeper/oauth/helpers/uri_checker"
       autoload :UniqueToken, "doorkeeper/oauth/helpers/unique_token"
+      autoload :ResourceIndicatorsChecker, "doorkeeper/oauth/helpers/resource_indicators_checker"
     end
 
     module Hooks
@@ -93,6 +97,7 @@ module Doorkeeper
     autoload :PolymorphicResourceOwner, "doorkeeper/models/concerns/polymorphic_resource_owner"
     autoload :Scopes, "doorkeeper/models/concerns/scopes"
     autoload :Reusable, "doorkeeper/models/concerns/reusable"
+    autoload :ResourceIndicators, "doorkeeper/models/concerns/resource_indicators"
     autoload :ResourceOwnerable, "doorkeeper/models/concerns/resource_ownerable"
     autoload :Revocable, "doorkeeper/models/concerns/revocable"
     autoload :SecretStorable, "doorkeeper/models/concerns/secret_storable"

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -118,6 +118,12 @@ module Doorkeeper
         @config.instance_variable_set(:@polymorphic_resource_owner, true)
       end
 
+      # Enabled Resource Indicator support. Requires additional database
+      # columns to be setup.
+      def use_resource_indicators
+        @config.instance_variable_set(:@use_resource_indicators, true)
+      end
+
       # Forbids creating/updating applications with arbitrary scopes that are
       # not in configuration, i.e. `default_scopes` or `optional_scopes`.
       # (disabled by default)
@@ -257,6 +263,9 @@ module Doorkeeper
     # Hook to allow arbitrary user-client authorization
     option :authorize_resource_owner_for_client,
            default: ->(_client, _resource_owner) { true }
+
+    option :resource_indicator_authorizer,
+           default: ->(_application, _resource_owner, _resource_indicators) { true }
 
     # Allows to customize OAuth grant flows that +each+ application support.
     # You can configure a custom block (or use a class respond to `#call`) that must
@@ -491,6 +500,10 @@ module Doorkeeper
 
     def polymorphic_resource_owner?
       option_set? :polymorphic_resource_owner
+    end
+
+    def using_resource_indicators?
+      option_set? :use_resource_indicators
     end
 
     def confirm_application_owner?

--- a/lib/doorkeeper/helpers/resource_indicators.rb
+++ b/lib/doorkeeper/helpers/resource_indicators.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module Helpers
+    # The RFC for resource indicators allows for multiple to be specified using this syntax:
+    #  GET /as/authorization.oauth2?response_type=code
+    #  ...
+    #  &scope=calendar%20contacts
+    #  &resource=https%3A%2F%2Fcal.example.com%2F
+    #  &resource=https%3A%2F%2Fcontacts.example.com%2F
+    #
+    # The default ActionController query paramater parsing will not accept that as an array
+    # so we've got to do it ourselves. Post body request parsing also sees the same issue.
+    module ResourceIndicators
+      def self.resource_identifier_from_request(request, existing_params)
+        resource_params = params_from_query(request)
+        resource_params = resource_params.merge(params_from_post(request)) unless resource_params.key?("resource")
+        resource_params = ActionController::Parameters.new(resource_params).slice(:resource).permit(resource: [])
+        existing_params.merge(resource_params)
+      end
+
+      def self.params_from_post(request)
+        return {} unless request.raw_post
+
+        parsed_body = CGI.parse(request.raw_post)
+        resources = parsed_body["resource"].presence || parsed_body["resource[]"].presence
+        if resources
+          { "resource" => resources }
+        else
+          {}
+        end
+      end
+
+      def self.params_from_query(request)
+        URI.parse(request.original_url).query.then do |query|
+          return {} unless query
+
+          { "resource" => CGI.parse(query)["resource"] }
+        end
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/models/access_grant_mixin.rb
+++ b/lib/doorkeeper/models/access_grant_mixin.rb
@@ -12,6 +12,7 @@ module Doorkeeper
     include Models::SecretStorable
     include Models::Scopes
     include Models::ResourceOwnerable
+    include Models::ResourceIndicators
 
     # Never uses PKCE if PKCE migrations were not generated
     def uses_pkce?

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -12,6 +12,7 @@ module Doorkeeper
     include Models::Orderable
     include Models::SecretStorable
     include Models::Scopes
+    include Models::ResourceIndicators
     include Models::ResourceOwnerable
     include Models::ExpirationTimeSqlMath
 
@@ -87,10 +88,10 @@ module Doorkeeper
       # @return [Doorkeeper::AccessToken, nil] Access Token instance or
       #   nil if matching record was not found
       #
-      def matching_token_for(application, resource_owner, scopes, include_expired: true)
+      def matching_token_for(application, resource_owner, scopes, resource_indicators = [], include_expired: true)
         tokens = authorized_tokens_for(application&.id, resource_owner)
         tokens = tokens.not_expired unless include_expired
-        find_matching_token(tokens, application, scopes)
+        find_matching_token(tokens, application, scopes, resource_indicators)
       end
 
       # Interface to enumerate access token records in batches in order not
@@ -114,11 +115,11 @@ module Doorkeeper
       #   Application instance
       # @param scopes [String, Doorkeeper::OAuth::Scopes]
       #   set of scopes
-      #
+      # @param resource_indicators [String, Doorkeeper::OAuth::ResourceIndicators]
+      #   set of resource indicators
       # @return [Doorkeeper::AccessToken, nil] Access Token instance or
       #   nil if matching record was not found
-      #
-      def find_matching_token(relation, application, scopes)
+      def find_matching_token(relation, application, scopes, resource_indicators)
         return nil unless relation
 
         matching_tokens = []
@@ -126,7 +127,8 @@ module Doorkeeper
 
         find_access_token_in_batches(relation, batch_size: batch_size) do |batch|
           tokens = batch.select do |token|
-            scopes_match?(token.scopes, scopes, application&.scopes)
+            scopes_match?(token.scopes, scopes, application&.scopes) &&
+              token.resource_indicators_match?(resource_indicators)
           end
 
           matching_tokens.concat(tokens)
@@ -179,9 +181,9 @@ module Doorkeeper
       #
       # @return [Doorkeeper::AccessToken] existing record or a new one
       #
-      def find_or_create_for(application:, resource_owner:, scopes:, **token_attributes)
+      def find_or_create_for(application:, resource_owner:, scopes:, resource_indicators: [], **token_attributes)
         if Doorkeeper.config.reuse_access_token
-          access_token = matching_token_for(application, resource_owner, scopes, include_expired: false)
+          access_token = matching_token_for(application, resource_owner, scopes, resource_indicators, include_expired: false)
 
           return access_token if access_token&.reusable?
         end
@@ -190,6 +192,7 @@ module Doorkeeper
           application: application,
           resource_owner: resource_owner,
           scopes: scopes,
+          resource_indicators: resource_indicators,
           **token_attributes,
         )
       end
@@ -205,6 +208,8 @@ module Doorkeeper
       #   set of scopes (any object that responds to `#to_s`)
       # @param token_attributes [Hash]
       #   Additional attributes to use when creating a token
+      # @param resource_indicators [Hash]
+      #   Resource indicators to use when creating a token, if enabled.
       # @option token_attributes [Integer] :expires_in
       #   token lifetime in seconds
       # @option token_attributes [Boolean] :use_refresh_token
@@ -212,7 +217,7 @@ module Doorkeeper
       #
       # @return [Doorkeeper::AccessToken] new access token
       #
-      def create_for(application:, resource_owner:, scopes:, **token_attributes)
+      def create_for(application:, resource_owner:, scopes:, resource_indicators: [], **token_attributes)
         token_attributes[:application] = application
         token_attributes[:scopes] = scopes.to_s
 
@@ -221,6 +226,8 @@ module Doorkeeper
         else
           token_attributes[:resource_owner_id] = resource_owner_id_for(resource_owner)
         end
+
+        token_attributes[:resource_indicators] = resource_indicators if Doorkeeper.config.using_resource_indicators?
 
         create!(token_attributes)
       end
@@ -378,6 +385,12 @@ module Doorkeeper
 
       old_refresh_token&.revoke
       update_attribute(:previous_refresh_token, "")
+    end
+
+    def resource_indicators_match?(requested_indicators)
+      return true unless Doorkeeper.config.using_resource_indicators?
+
+      resource_indicators.contains_all?(requested_indicators)
     end
 
     private

--- a/lib/doorkeeper/models/concerns/resource_indicators.rb
+++ b/lib/doorkeeper/models/concerns/resource_indicators.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module Models
+    # Provides getters and setters for resource indicators. Since we can't rely on
+    # database specifics like array types resource indicators are stored as a string
+    # in the database - similar to scopes.
+    module ResourceIndicators
+      def resource_indicators
+        OAuth::ResourceIndicators.from_string(resource_indicators_string)
+      end
+
+      def resource_indicators=(value)
+        if value.is_a?(Array)
+          super(Doorkeeper::OAuth::ResourceIndicators.from_array(value).to_s)
+        else
+          super(Doorkeeper::OAuth::ResourceIndicators.from_string(value.to_s).to_s)
+        end
+      end
+
+      def resource_indicators_string
+        self[:resource_indicators]
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/authorization/code.rb
+++ b/lib/doorkeeper/oauth/authorization/code.rb
@@ -39,6 +39,10 @@ module Doorkeeper
             scopes: pre_auth.scopes.to_s,
           }
 
+          if Doorkeeper.config.using_resource_indicators?
+            attributes[:resource_indicators] = pre_auth.resource_indicators
+          end
+
           if Doorkeeper.config.polymorphic_resource_owner?
             attributes[:resource_owner] = resource_owner
           else

--- a/lib/doorkeeper/oauth/authorization/context.rb
+++ b/lib/doorkeeper/oauth/authorization/context.rb
@@ -4,7 +4,7 @@ module Doorkeeper
   module OAuth
     module Authorization
       class Context
-        attr_reader :client, :grant_type, :resource_owner, :scopes
+        attr_reader :client, :grant_type, :resource_owner, :scopes, :resource_indicators
 
         def initialize(**attributes)
           attributes.each do |name, value|

--- a/lib/doorkeeper/oauth/authorization/token.rb
+++ b/lib/doorkeeper/oauth/authorization/token.rb
@@ -65,6 +65,7 @@ module Doorkeeper
             scopes: pre_auth.scopes,
             expires_in: self.class.access_token_expires_in(Doorkeeper.config, context),
             use_refresh_token: false,
+            resource_indicators: pre_auth.resource_indicators,
           )
         end
 

--- a/lib/doorkeeper/oauth/base_request.rb
+++ b/lib/doorkeeper/oauth/base_request.rb
@@ -26,7 +26,7 @@ module Doorkeeper
         @scopes ||= build_scopes
       end
 
-      def find_or_create_access_token(client, resource_owner, scopes, custom_attributes, server)
+      def find_or_create_access_token(client, resource_owner, scopes, resource_indicators, custom_attributes, server)
         context = Authorization::Token.build_context(client, grant_type, scopes, resource_owner)
         application = client.is_a?(Doorkeeper.config.application_model) ? client : client&.application
 
@@ -36,6 +36,7 @@ module Doorkeeper
           scopes: scopes,
           expires_in: Authorization::Token.access_token_expires_in(server, context),
           use_refresh_token: Authorization::Token.refresh_token_enabled?(server, context),
+          resource_indicators: resource_indicators,
         }
 
         @access_token =

--- a/lib/doorkeeper/oauth/client_credentials/issuer.rb
+++ b/lib/doorkeeper/oauth/client_credentials/issuer.rb
@@ -37,6 +37,7 @@ module Doorkeeper
           creator.call(
             client,
             scopes,
+            resource_indicators: validator.resource_indicators,
             use_refresh_token: false,
             expires_in: ttl,
           )

--- a/lib/doorkeeper/oauth/client_credentials/validator.rb
+++ b/lib/doorkeeper/oauth/client_credentials/validator.rb
@@ -10,6 +10,7 @@ module Doorkeeper
         validate :client, error: :invalid_client
         validate :client_supports_grant_flow, error: :unauthorized_client
         validate :scopes, error: :invalid_scope
+        validate :resource_indicators, error: :invalid_target
 
         def initialize(server, request)
           @server = server
@@ -19,7 +20,21 @@ module Doorkeeper
           validate
         end
 
+        def resource_indicators
+          @request.resource
+        end
+
         private
+
+        def validate_resource_indicators
+          return true unless Doorkeeper.config.using_resource_indicators?
+
+          Doorkeeper.configuration.resource_indicator_authorizer.call(
+            @client.application,
+            nil,
+            @request.resource,
+          )
+        end
 
         def validate_client
           @client.present?

--- a/lib/doorkeeper/oauth/client_credentials_request.rb
+++ b/lib/doorkeeper/oauth/client_credentials_request.rb
@@ -3,7 +3,7 @@
 module Doorkeeper
   module OAuth
     class ClientCredentialsRequest < BaseRequest
-      attr_reader :client, :original_scopes, :response
+      attr_reader :client, :original_scopes, :response, :resource
 
       alias error_response response
 
@@ -14,6 +14,7 @@ module Doorkeeper
         @server = server
         @response = nil
         @original_scopes = parameters[:scope]
+        @resource = OAuth::ResourceIndicators.from_array parameters[:resource]
       end
 
       def access_token

--- a/lib/doorkeeper/oauth/concerns/list_like.rb
+++ b/lib/doorkeeper/oauth/concerns/list_like.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OAuth
+    # ListLike is a mixin for the common functionality in both the
+    # ResourceIndicator and Scope sets.
+    module ListLike
+      extend ActiveSupport::Concern
+      include Enumerable
+      include Comparable
+
+      class_methods do
+        def from_string(string)
+          string ||= ""
+          new.tap do |collection|
+            collection.add(*string.split)
+          end
+        end
+
+        def from_array(array)
+          new.tap do |collection|
+            collection.add(*array)
+          end
+        end
+      end
+
+      delegate :each, :empty?, to: :@collection
+
+      def initialize
+        @collection = []
+      end
+
+      def exists?(collection_item)
+        @collection.include? collection_item.to_s
+      end
+
+      def add(*collection)
+        @collection.push(*collection.map(&:to_s))
+        @collection.uniq!
+      end
+
+      def all
+        @collection
+      end
+
+      def to_s
+        @collection.join(" ")
+      end
+
+      def contains_all?(collection)
+        collection.all? { |collection_item| exists?(collection_item) }
+      end
+
+      def +(other)
+        self.class.from_array(all + to_array(other))
+      end
+
+      def <=>(other)
+        if other.respond_to?(:map)
+          map(&:to_s).sort <=> other.map(&:to_s).sort
+        else
+          super
+        end
+      end
+
+      def &(other)
+        self.class.from_array(all & to_array(other))
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/error_response.rb
+++ b/lib/doorkeeper/oauth/error_response.rb
@@ -5,7 +5,7 @@ module Doorkeeper
     class ErrorResponse < BaseResponse
       include OAuth::Helpers
 
-      NON_REDIRECTABLE_STATES = %i[invalid_redirect_uri invalid_client unauthorized_client].freeze
+      NON_REDIRECTABLE_STATES = %i[invalid_redirect_uri invalid_client unauthorized_client invalid_target].freeze
 
       def self.from_request(request, attributes = {})
         new(
@@ -34,7 +34,7 @@ module Doorkeeper
       end
 
       def status
-        if name == :invalid_client || name == :unauthorized_client
+        if %i[invalid_client invalid_target unauthorized_client].include?(name)
           :unauthorized
         else
           :bad_request

--- a/lib/doorkeeper/oauth/helpers/resource_indicators_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/resource_indicators_checker.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OAuth
+    module Helpers
+      # ResourceIndicatorsChecker validates that a provided set of indicators is valid
+      # for a given grant. A grant should contain the same or more grants for any provided set.
+      module ResourceIndicatorsChecker
+        def self.valid?(grant, requested_indicators)
+          return true unless Doorkeeper.config.using_resource_indicators?
+
+          grant.resource_indicators.contains_all?(requested_indicators)
+        end
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/invalid_target_response.rb
+++ b/lib/doorkeeper/oauth/invalid_target_response.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OAuth
+    class InvalidTargetResponse < ErrorResponse
+      attr_reader :reason
+
+      def self.from_request(request, attributes = {})
+        new(
+          attributes.merge(
+            state: request.try(:state),
+            redirect_uri: request.try(:redirect_uri),
+            missing_param: request.try(:missing_param),
+            reason: request.try(:invalid_request_reason),
+          ),
+        )
+      end
+
+      def initialize(attributes = {})
+        super(attributes.merge(name: :invalid_request))
+        @missing_param = attributes[:missing_param]
+        @reason = @missing_param.nil? ? attributes[:reason] : :missing_param
+      end
+
+      def status
+        :bad_request
+      end
+
+      def description
+        I18n.translate(
+          reason,
+          scope: %i[doorkeeper errors messages invalid_request],
+          default: :unknown,
+          value: @missing_param,
+        )
+      endv
+      def redirectable?
+        super && @missing_param != :client_id
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -9,6 +9,7 @@ module Doorkeeper
       validate :client_supports_grant_flow, error: :unauthorized_client
       validate :resource_owner, error: :invalid_grant
       validate :scopes, error: :invalid_scope
+      validate :resource_indicators, error: :invalid_target
 
       attr_reader :client, :credentials, :resource_owner, :parameters, :access_token
 
@@ -20,12 +21,27 @@ module Doorkeeper
         @parameters      = parameters
         @original_scopes = parameters[:scope]
         @grant_type      = Doorkeeper::OAuth::PASSWORD
+        @resource        = parameters[:resource]
       end
 
       private
 
+      def validate_resource_indicators
+        return true unless Doorkeeper.config.using_resource_indicators?
+      
+        Doorkeeper.configuration.resource_indicator_authorizer.call(
+          client.application,
+          resource_owner,
+          resource_indicators,
+        )
+      end
+      
+      def resource_indicators
+        @resource_indicators ||= ResourceIndicators.from_array(@resource)
+      end
+
       def before_successful_response
-        find_or_create_access_token(client, resource_owner, scopes, {}, server)
+        find_or_create_access_token(client, resource_owner, scopes, resource_indicators, {}, server)
         super
       end
 

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -11,6 +11,7 @@ module Doorkeeper
       validate :resource_owner_authorize_for_client, error: :invalid_client
       validate :redirect_uri, error: :invalid_redirect_uri
       validate :params, error: :invalid_request
+      validate :resource_indicators, error: :invalid_target
       validate :response_type, error: :unsupported_response_type
       validate :response_mode, error: :unsupported_response_mode
       validate :scopes, error: :invalid_scope
@@ -18,7 +19,8 @@ module Doorkeeper
 
       attr_reader :client, :code_challenge, :code_challenge_method, :missing_param,
                   :redirect_uri, :resource_owner, :response_type, :state,
-                  :authorization_response_flow, :response_mode, :custom_access_token_attributes
+                  :authorization_response_flow, :response_mode, :resource,
+                  :custom_access_token_attributes
 
       def initialize(server, parameters = {}, resource_owner = nil)
         @server = server
@@ -31,6 +33,7 @@ module Doorkeeper
         @code_challenge = parameters[:code_challenge]
         @code_challenge_method = parameters[:code_challenge_method]
         @resource_owner = resource_owner
+        @resource = ResourceIndicators.from_array(parameters[:resource])
         @custom_access_token_attributes = parameters.slice(*Doorkeeper.config.custom_access_token_attributes)
       end
 
@@ -40,6 +43,10 @@ module Doorkeeper
 
       def scopes
         Scopes.from_string(scope)
+      end
+
+      def resource_indicators
+        @resource
       end
 
       def scope
@@ -95,6 +102,16 @@ module Doorkeeper
       def validate_resource_owner_authorize_for_client
         # The `authorize_resource_owner_for_client` config option is used for this validation
         client.application.authorized_for_resource_owner?(@resource_owner)
+      end
+
+      def validate_resource_indicators
+        return true unless Doorkeeper.config.using_resource_indicators?
+
+        Doorkeeper.configuration.resource_indicator_authorizer.call(
+          client.application,
+          @resource_owner,
+          resource_indicators,
+        )
       end
 
       def validate_redirect_uri

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -5,14 +5,14 @@ module Doorkeeper
     class RefreshTokenRequest < BaseRequest
       include OAuth::Helpers
 
-      validate :token_presence, error: :invalid_request
-      validate :token,        error: :invalid_grant
-      validate :client,       error: :invalid_client
-      validate :client_match, error: :invalid_grant
-      validate :scope,        error: :invalid_scope
+      validate :token_presence,      error: :invalid_request
+      validate :token,               error: :invalid_grant
+      validate :client,              error: :invalid_client
+      validate :client_match,        error: :invalid_grant
+      validate :scope,               error: :invalid_scope
+      validate :resource_indicators, error: :invalid_target
 
-      attr_reader :access_token, :client, :credentials, :refresh_token
-      attr_reader :missing_param
+      attr_reader :access_token, :client, :credentials, :refresh_token, :missing_param
 
       def initialize(server, refresh_token, credentials, parameters = {})
         @server = server
@@ -21,9 +21,18 @@ module Doorkeeper
         @original_scopes = parameters[:scope] || parameters[:scopes]
         @refresh_token_parameter = parameters[:refresh_token]
         @client = load_client(credentials) if credentials
+        @resource = parameters[:resource]
       end
 
       private
+
+      def validate_resource_indicators
+        Helpers::ResourceIndicatorsChecker.valid?(@refresh_token, resource_indicators)
+      end
+
+      def resource_indicators
+        @resource_indicators ||= ResourceIndicators.from_array(@resource)
+      end
 
       def load_client(credentials)
         Doorkeeper.config.application_model.by_uid_and_secret(credentials.uid, credentials.secret)
@@ -58,9 +67,9 @@ module Doorkeeper
             refresh_token.resource_owner_id
           end
 
-        if refresh_token_revoked_on_use?
-          attributes[:previous_refresh_token] = refresh_token.refresh_token
-        end
+        attributes[:previous_refresh_token] = refresh_token.refresh_token if refresh_token_revoked_on_use?
+
+        attributes[:resource_indicators] = resource_indicators if Doorkeeper.config.using_resource_indicators?
 
         # RFC6749
         # 1.5.  Refresh Token

--- a/lib/doorkeeper/oauth/resource_indicators.rb
+++ b/lib/doorkeeper/oauth/resource_indicators.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OAuth
+    # Represents a set of resource indicators, much like the matching Scope class.
+    class ResourceIndicators
+      include OAuth::ListLike
+
+      alias has_resource_indicators? contains_all?
+      alias resource_indicators? contains_all?
+
+      def common_or_lesser(other)
+        intersection(other)
+      end
+
+      private
+
+      def to_array(other)
+        case other
+        when ResourceIndicators
+          other.all
+        else
+          other.to_a
+        end
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/scopes.rb
+++ b/lib/doorkeeper/oauth/scopes.rb
@@ -3,66 +3,10 @@
 module Doorkeeper
   module OAuth
     class Scopes
-      include Enumerable
-      include Comparable
+      include OAuth::ListLike
 
-      def self.from_string(string)
-        string ||= ""
-        new.tap do |scope|
-          scope.add(*string.split)
-        end
-      end
-
-      def self.from_array(array)
-        new.tap do |scope|
-          scope.add(*array)
-        end
-      end
-
-      delegate :each, :empty?, to: :@scopes
-
-      def initialize
-        @scopes = []
-      end
-
-      def exists?(scope)
-        @scopes.include? scope.to_s
-      end
-
-      def add(*scopes)
-        @scopes.push(*scopes.map(&:to_s))
-        @scopes.uniq!
-      end
-
-      def all
-        @scopes
-      end
-
-      def to_s
-        @scopes.join(" ")
-      end
-
-      def scopes?(scopes)
-        scopes.all? { |scope| exists?(scope) }
-      end
-
-      alias has_scopes? scopes?
-
-      def +(other)
-        self.class.from_array(all + to_array(other))
-      end
-
-      def <=>(other)
-        if other.respond_to?(:map)
-          map(&:to_s).sort <=> other.map(&:to_s).sort
-        else
-          super
-        end
-      end
-
-      def &(other)
-        self.class.from_array(all & to_array(other))
-      end
+      alias has_scopes? contains_all?
+      alias scopes? contains_all?
 
       private
 

--- a/lib/doorkeeper/server.rb
+++ b/lib/doorkeeper/server.rb
@@ -20,7 +20,10 @@ module Doorkeeper
 
     # TODO: context should be the request
     def parameters
-      context.request.parameters
+      Doorkeeper::Helpers::ResourceIndicators.resource_identifier_from_request(
+        context.request,
+        context.request.parameters,
+      )
     end
 
     def client

--- a/lib/generators/doorkeeper/enable_resource_indicators_generator.rb
+++ b/lib/generators/doorkeeper/enable_resource_indicators_generator.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Doorkeeper
+  # Generates migration to add resource indicator support to the
+  # doorkeeper tables.
+  #
+  class EnableResourceIndicatorsGenerator < ::Rails::Generators::Base
+    include ::Rails::Generators::Migration
+    source_root File.expand_path("templates", __dir__)
+    desc "Support Resource Indicators for OAuth 2 (rfc8707)"
+
+    def self.next_migration_number(path)
+      ActiveRecord::Generators::Base.next_migration_number(path)
+    end
+
+    def previous_refresh_token
+      migration_template(
+        "add_resource_indicators_to_access_grants_and_access_tokens.rb.erb",
+        "db/migrate/add_resource_indicators_to_access_grants_and_access_tokens.rb",
+      )
+      gsub_file(
+        "config/initializers/doorkeeper.rb",
+        "# use_resource_indicators",
+        "use_resource_indicators",
+      )
+    end
+
+    private
+
+    def migration_version
+      "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
+    end
+  end
+end

--- a/lib/generators/doorkeeper/templates/add_resource_indicators_to_access_grants_and_access_tokens.rb.erb
+++ b/lib/generators/doorkeeper/templates/add_resource_indicators_to_access_grants_and_access_tokens.rb.erb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddResourceIndicatorsToAccessGrantsAndAccessTokens < ActiveRecord::Migration<%= migration_version %>
+  def change
+    add_column(
+      :oauth_access_grants,
+      :resource_indicators,
+      :string,
+      null: true,
+    )
+
+    add_column(
+      :oauth_access_tokens,
+      :resource_indicators,
+      :string,
+      null: true,
+    )
+  end
+end

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -506,4 +506,20 @@ Doorkeeper.configure do
   # WWW-Authenticate Realm (default: "Doorkeeper").
   #
   # realm "Doorkeeper"
+
+  # Enables resource indicator (https://datatracker.ietf.org/doc/html/rfc8707) support.
+  # When enabled access request will delegate to the below callback to verify that the resource
+  # paramater provided by calling apps is appropriate for your application.
+  #
+  # Although the RFC suggests to use urls for indicators there's no restriction on their form
+  # and it's entirely up to your code to make a judgement as to if the resource owner, indicator
+  # pair is valid.
+  #
+  # Authorized resources are saved to the AccessToken for inspection on your protected endpoints.
+  #
+  # use_resource_indicators
+  #
+  resource_indicator_authorizer do |_application, _resource_owner, _resource_indicators|
+    raise "Please configure doorkeeper resource_indicator_authorizer block located in #{__FILE__}"
+  end
 end

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -78,6 +78,52 @@ RSpec.describe Doorkeeper::AuthorizationsController, type: :controller do
       end
     end
 
+    context "with resource indicators enabled" do
+      before do
+        allow(Doorkeeper.configuration).to receive(:using_resource_indicators?).and_return(true)
+        allow(Doorkeeper.configuration).to receive(:resource_indicator_authorizer).and_return(->(*_) { true })
+        post :create, params: {
+          client_id: client.uid,
+          response_type: "token",
+          redirect_uri: client.redirect_uri,
+          resource: "http://example.com/resource",
+        }
+      end
+
+      it "redirects after authorization" do
+        expect(response).to be_redirect
+        expect(controller).to receive(:authenticator_method).at_most(:once)
+      end
+
+      it "redirects to client redirect uri" do
+        expect(response.location).to match(/^#{client.redirect_uri}/)
+      end
+
+      it "includes access token in fragment" do
+        expect(response.query_params["access_token"]).to eq(Doorkeeper::AccessToken.first.token)
+      end
+
+      it "includes token type in fragment" do
+        expect(response.query_params["token_type"]).to eq("Bearer")
+      end
+
+      it "includes token expiration in fragment" do
+        expect(response.query_params["expires_in"].to_i).to eq(1234)
+      end
+
+      it "issues the token for the current client" do
+        expect(Doorkeeper::AccessToken.first.application_id).to eq(client.id)
+      end
+
+      it "issues the token for the current resource owner" do
+        expect(Doorkeeper::AccessToken.first.resource_owner_id).to eq(user.id)
+      end
+
+      it "issues the token for the resource indicator" do
+        expect(Doorkeeper::AccessToken.first.resource_indicators).to contain_exactly("http://example.com/resource")
+      end
+    end
+
     context "with 'form_post' as response_mode" do
       before do
         post :create, params: {
@@ -268,6 +314,40 @@ RSpec.describe Doorkeeper::AuthorizationsController, type: :controller do
       it "includes error description" do
         expect(response_json_body["error_description"]).to eq(
           translated_error_message(:invalid_client),
+        )
+      end
+
+      it "does not issue any access token" do
+        expect(Doorkeeper::AccessToken.all).to be_empty
+      end
+    end
+
+    context "when the user does not have access to the resource" do
+      before do
+        allow(Doorkeeper.configuration).to receive(:using_resource_indicators?).and_return(true)
+        allow(Doorkeeper.configuration).to receive(:resource_indicator_authorizer).and_return(->(*_) { false })
+        post :create, params: {
+          client_id: client.uid,
+          response_type: "token",
+          redirect_uri: client.redirect_uri,
+          resource: "http://example.com/resource",
+        }
+      end
+
+      let(:callback_double) { double(call: false) }
+      let(:response_json_body) { JSON.parse(response.body) }
+
+      it "renders 401 error" do
+        expect(response.status).to eq 401
+      end
+
+      it "includes error name" do
+        expect(response_json_body["error"]).to eq("invalid_target")
+      end
+
+      it "includes error description" do
+        expect(response_json_body["error_description"]).to eq(
+          translated_error_message(:invalid_target),
         )
       end
 

--- a/spec/dummy/db/migrate/20220224160655_add_resource_indicators_to_access_grants_and_access_tokens.rb
+++ b/spec/dummy/db/migrate/20220224160655_add_resource_indicators_to_access_grants_and_access_tokens.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddResourceIndicatorsToAccessGrantsAndAccessTokens < ActiveRecord::Migration[7.0]
+  def change
+    add_column(
+      :oauth_access_grants,
+      :resource_indicators,
+      :string,
+      null: true,
+    )
+
+    add_column(
+      :oauth_access_tokens,
+      :resource_indicators,
+      :string,
+      null: true,
+    )
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20230205064514) do
     t.datetime "created_at", null: false
     t.datetime "revoked_at"
     t.string "scopes"
+    t.string "resource_indicators"
     t.string "tenant_name"
     unless ENV["WITHOUT_PKCE"]
       t.string   "code_challenge"
@@ -41,6 +42,7 @@ ActiveRecord::Schema.define(version: 20230205064514) do
     t.datetime "created_at", null: false
     t.string "scopes"
     t.string "previous_refresh_token", default: "", null: false
+    t.string "resource_indicators"
     t.string "tenant_name"
     t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
     t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"

--- a/spec/generators/enable_resource_indicators_generator_spec.rb
+++ b/spec/generators/enable_resource_indicators_generator_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "generators/doorkeeper/enable_resource_indicators_generator"
+
+RSpec.describe Doorkeeper::EnableResourceIndicatorsGenerator do
+  include GeneratorSpec::TestCase
+
+  tests described_class
+  destination ::File.expand_path("tmp/dummy", __dir__)
+
+  describe "after running the generator" do
+    before do
+      prepare_destination
+      FileUtils.mkdir_p(::File.expand_path("config/initializers", Pathname(destination_root)))
+      FileUtils.copy_file(
+        ::File.expand_path("../../lib/generators/doorkeeper/templates/initializer.rb", __dir__),
+        ::File.expand_path("config/initializers/doorkeeper.rb", Pathname.new(destination_root)),
+      )
+    end
+
+    it "creates a migration with a version specifier" do
+      stub_const("ActiveRecord::VERSION::MAJOR", 5)
+      stub_const("ActiveRecord::VERSION::MINOR", 0)
+
+      run_generator
+
+      assert_migration "db/migrate/add_resource_indicators_to_access_grants_and_access_tokens.rb" do |migration|
+        assert migration.include?("ActiveRecord::Migration[5.0]\n")
+      end
+
+      expect(destination_root).to(have_structure do
+        directory "config" do
+          directory "initializers" do
+            file "doorkeeper.rb" do
+              contains "  use_resource_indicators"
+            end
+          end
+        end
+      end)
+    end
+  end
+end

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
                       resource_owner_type: resource_owner.class.name
   end
   let(:client) { grant.application }
-  let(:redirect_uri) { client.redirect_uri }
-  let(:params) { { redirect_uri: redirect_uri } }
+  let(:params) { { redirect_uri: client.redirect_uri } }
 
   before do
     allow(server).to receive(:option_defined?).with(:custom_access_token_expires_in).and_return(true)
@@ -136,8 +135,72 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
     request.authorize
   end
 
+  context "with a grant with resource indicators" do
+    before do
+      grant.update(resource_indicators: ["http://example.com/resource1", "http://example.com/resource2"])
+      allow(Doorkeeper.config).to receive(:using_resource_indicators?).and_return true
+    end
+
+    context "when matching resource indicators are specified" do
+      let(:params) do
+        {
+          redirect_uri: client.redirect_uri,
+          resource: ["http://example.com/resource1", "http://example.com/resource2"],
+        }
+      end
+
+      it "issues a new token for the client" do
+        expect do
+          request.authorize
+        end.to change { client.reload.access_tokens.count }.by(1)
+        expect(client.access_tokens.last.resource_indicators.all).to eq ["http://example.com/resource1", "http://example.com/resource2"]
+      end
+    end
+
+    context "when a subset resource indicators are specified" do
+      let(:params) do
+        {
+          redirect_uri: client.redirect_uri,
+          resource: "http://example.com/resource1",
+        }
+      end
+
+      it "issues a new token for the client" do
+        expect do
+          request.authorize
+        end.to change { client.reload.access_tokens.count }.by(1)
+        expect(client.access_tokens.last.resource_indicators).to contain_exactly "http://example.com/resource1"
+      end
+    end
+
+    context "when resource indicators are omitted" do
+      it "returns a downgraded token" do
+        expect do
+          request.authorize
+        end.to change { client.reload.access_tokens.count }.by(1)
+        expect(client.access_tokens.last.resource_indicators).to be_empty
+      end
+    end
+
+    context "when a superset resource indicators are specified" do
+      let(:params) do
+        {
+          redirect_uri: client.redirect_uri,
+          resource: ["http://example.com/resource1", "http://example.com/resource2", "http://example.com/resource3"],
+        }
+      end
+
+      it "issues a new token for the client" do
+        expect do
+          request.authorize
+        end.to change { client.reload.access_tokens.count }.by(0)
+        expect(request.error).to eq(:invalid_target)
+      end
+    end
+  end
+
   context "when redirect_uri contains some query params" do
-    let(:redirect_uri) { "#{client.redirect_uri}?query=q" }
+    let(:params) { { redirect_uri: "#{client.redirect_uri}?query=q" } }
 
     it "allows query params" do
       request.validate
@@ -146,7 +209,7 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
   end
 
   context "when redirect_uri is not an URI" do
-    let(:redirect_uri) { "123d#!s" }
+    let(:params) { { redirect_uri: "123d#!s" } }
 
     it "responds with invalid_grant" do
       request.validate
@@ -155,7 +218,7 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
   end
 
   context "when redirect_uri is the native one" do
-    let(:redirect_uri) { "urn:ietf:wg:oauth:2.0:oob" }
+    let(:params) { { redirect_uri: "urn:ietf:wg:oauth:2.0:oob" } }
 
     it "invalidates when redirect_uri of the grant is not native" do
       request.validate
@@ -163,7 +226,7 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
     end
 
     it "validates when redirect_uri of the grant is also native" do
-      allow(grant).to receive(:redirect_uri) { redirect_uri }
+      allow(grant).to receive(:redirect_uri).and_return "urn:ietf:wg:oauth:2.0:oob"
       request.validate
       expect(request.error).to eq(nil)
     end

--- a/spec/lib/oauth/base_request_spec.rb
+++ b/spec/lib/oauth/base_request_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe Doorkeeper::OAuth::BaseRequest do
         client,
         resource_owner,
         "public",
+        [],
         {},
         server,
       )
@@ -145,6 +146,7 @@ RSpec.describe Doorkeeper::OAuth::BaseRequest do
         client,
         resource_owner,
         "public",
+        [],
         {},
         server,
       )
@@ -167,6 +169,7 @@ RSpec.describe Doorkeeper::OAuth::BaseRequest do
         client,
         resource_owner,
         "public",
+        [],
         {},
         server,
       )
@@ -176,6 +179,7 @@ RSpec.describe Doorkeeper::OAuth::BaseRequest do
         client,
         resource_owner,
         "private",
+        [],
         {},
         server,
       )

--- a/spec/lib/oauth/client_credentials/issuer_spec.rb
+++ b/spec/lib/oauth/client_credentials/issuer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Issuer do
       access_token_expires_in: 100,
     )
   end
-  let(:validator) { double :validator, valid?: true }
+  let(:validator) { double :validator, valid?: true, resource_indicators: [] }
 
   before do
     allow(server).to receive(:option_defined?).with(:custom_access_token_expires_in).and_return(false)
@@ -33,6 +33,7 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Issuer do
       expect(creator).to receive(:call).with(
         client,
         scopes,
+        resource_indicators: [],
         expires_in: 100,
         use_refresh_token: false,
       )
@@ -90,6 +91,7 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Issuer do
         expect(creator).to receive(:call).with(
           client,
           scopes,
+          resource_indicators: [],
           expires_in: custom_ttl_grant,
           use_refresh_token: false,
         )
@@ -100,6 +102,7 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Issuer do
         expect(creator).to receive(:call).with(
           client,
           custom_scope,
+          resource_indicators: [],
           expires_in: custom_ttl_scope,
           use_refresh_token: false,
         )

--- a/spec/lib/oauth/code_response_spec.rb
+++ b/spec/lib/oauth/code_response_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Doorkeeper::OAuth::CodeResponse do
       redirect_uri: "http://tst.com/cb",
       state: "state",
       scopes: Doorkeeper::OAuth::Scopes.from_string("public"),
+      resource_indicators: [],
       custom_access_token_attributes: {},
     )
   end

--- a/spec/lib/oauth/helpers/resource_indicators_checker_spec.rb
+++ b/spec/lib/oauth/helpers/resource_indicators_checker_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::OAuth::Helpers::ResourceIndicatorsChecker do
+  describe ".valid?" do
+    before do
+      allow(Doorkeeper.config).to receive(:using_resource_indicators?).and_return(true)
+    end
+
+    let(:subject) do
+      described_class.valid?(
+        double(resource_indicators: Doorkeeper::OAuth::ResourceIndicators.from_array(preapproved_indicators)),
+        Doorkeeper::OAuth::ResourceIndicators.from_array(requested_indicators),
+      )
+    end
+
+    context "when preapproved is a superset" do
+      let(:preapproved_indicators) do
+        ["http://example.com/1", "http://example.com/2"]
+      end
+
+      let(:requested_indicators) do
+        ["http://example.com/1"]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when preapproved is a subset" do
+      let(:preapproved_indicators) do
+        ["http://example.com/1"]
+      end
+
+      let(:requested_indicators) do
+        ["http://example.com/1", "http://example.com/2"]
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when preapproved is a empty" do
+      let(:preapproved_indicators) do
+        []
+      end
+
+      let(:requested_indicators) do
+        ["http://example.com/1", "http://example.com/2"]
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when both are empty " do
+      let(:preapproved_indicators) do
+        []
+      end
+
+      let(:requested_indicators) do
+        []
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when both are set and equal" do
+      let(:preapproved_indicators) do
+        ["http://example.com/1"]
+      end
+
+      let(:requested_indicators) do
+        ["http://example.com/1"]
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -455,6 +455,26 @@ feature "Authorization Code Flow" do
     end
   end
 
+  context "with resource indicators" do
+    background do
+      config_is_set(:use_resource_indicators, true)
+    end
+
+    scenario "resource owner authorizes the client with default scopes" do
+      visit authorization_endpoint_url(client: @client, resource: "http://example.com/resource1")
+      click_on "Authorize"
+      access_grant_should_exist_for(@client, @resource_owner)
+      access_grant_should_have_resource_indicators "http://example.com/resource1"
+    end
+
+    scenario "with two resource indicators" do
+      visit "#{authorization_endpoint_url(client: @client, resource: "http://example.com/resource1")}&#{{ resource: "http://example.com/resource2" }.to_param}"
+      click_on "Authorize"
+      access_grant_should_exist_for(@client, @resource_owner)
+      access_grant_should_have_resource_indicators "http://example.com/resource1", "http://example.com/resource2"
+    end
+  end
+
   context "with scopes" do
     background do
       default_scopes_exist :public

--- a/spec/support/helpers/model_helper.rb
+++ b/spec/support/helpers/model_helper.rb
@@ -48,6 +48,11 @@ module ModelHelper
     expect(grant.scopes).to eq(Doorkeeper::OAuth::Scopes.from_array(args))
   end
 
+  def access_grant_should_have_resource_indicators(*args)
+    grant = Doorkeeper::AccessGrant.first
+    expect(grant.resource_indicators).to eq(Doorkeeper::OAuth::ResourceIndicators.from_array(args))
+  end
+
   def access_token_should_have_scopes(*args)
     grant = Doorkeeper::AccessToken.last
     expect(grant.scopes).to eq(Doorkeeper::OAuth::Scopes.from_array(args))

--- a/spec/support/helpers/url_helper.rb
+++ b/spec/support/helpers/url_helper.rb
@@ -10,6 +10,7 @@ module UrlHelper
       grant_type: options[:grant_type] || "authorization_code",
       code_verifier: options[:code_verifier],
       code_challenge_method: options[:code_challenge_method],
+      resource: options[:resource],
     }.reject { |_, v| v.blank? }
     "/oauth/token?#{build_query(parameters)}"
   end
@@ -37,6 +38,7 @@ module UrlHelper
       state: options[:state],
       code_challenge: options[:code_challenge],
       code_challenge_method: options[:code_challenge_method],
+      resource: options[:resource],
     }.reject { |_, v| v.blank? }
     "/oauth/authorize?#{build_query(parameters)}"
   end
@@ -47,6 +49,7 @@ module UrlHelper
       client_id: options[:client_id] || options[:client].try(:uid),
       client_secret: options[:client_secret] || options[:client].try(:secret),
       grant_type: options[:grant_type] || "refresh_token",
+      resource: options[:resource],
     }.reject { |_, v| v.blank? }
     "/oauth/token?#{build_query(parameters)}"
   end


### PR DESCRIPTION
Since we forked the original Doorkeeper repository in 2022 and merged some of our own PRs, a vulnerability CVE-2023-34246 has appeared, so we need to resync our fork and reapply our previous PRs (https://github.com/hopin-team/doorkeeper/pull/1 and https://github.com/hopin-team/doorkeeper/pull/2).

This is pretty straightforward, with the exception of some methods whose signature has changed on both sides, i.e. we added a parameter, and they added one as well.

To double-check my changes, I have done a "diff of diffs", i.e. what's the difference between our original patch (the 2 PRs mentioned above) and this new patch (this PR). The "diff of diffs"  shows this:

```
< -      def matching_token_for(application, resource_owner, scopes)
< +      def matching_token_for(application, resource_owner, scopes, resource_indicators = [])
<          tokens = authorized_tokens_for(application&.id, resource_owner).not_expired
---
> -      def matching_token_for(application, resource_owner, scopes, include_expired: true)
> +      def matching_token_for(application, resource_owner, scopes, resource_indicators = [], include_expired: true)
>          tokens = authorized_tokens_for(application&.id, resource_owner)
>          tokens = tokens.not_expired unless include_expired
```

so you can see we've added our `resource_indicators` positional argument at the same time they've added their `include_expired` keyword argument (luckily with a default value!).

The "diff of diffs" also shows this:

```
< -          access_token = matching_token_for(application, resource_owner, scopes)
< +          access_token = matching_token_for(application, resource_owner, scopes, resource_indicators)
---
> -          access_token = matching_token_for(application, resource_owner, scopes, include_expired: false)
> +          access_token = matching_token_for(application, resource_owner, scopes, resource_indicators, include_expired: false)
```

i.e. more of the same.

Also this:

```
< -      def find_or_create_access_token(client, resource_owner, scopes, server)
< +      def find_or_create_access_token(client, resource_owner, scopes, server, resource_indicators)
---
> -      def find_or_create_access_token(client, resource_owner, scopes, custom_attributes, server)
> +      def find_or_create_access_token(client, resource_owner, scopes, resource_indicators, custom_attributes, server)
```

You can see I've added our new `resource_indicators` after `scopes` so that `server` remains the last parameter, which I think was the author's intention. Our initial PRs added `resource_indicators` at the end.

Next is this:

```
< -        find_or_create_access_token(client, resource_owner, scopes, server)
< +        find_or_create_access_token(client, resource_owner, scopes, server, resource_indicators)
---
> -        find_or_create_access_token(client, resource_owner, scopes, {}, server)
> +        find_or_create_access_token(client, resource_owner, scopes, resource_indicators, {}, server)
```

Again, just adding our `resource_indicators` at the same time they've added their empty `{}` custom attributes.

All tests are passing:

```
% bundle exec rake spec
====> Doorkeeper ORM: 'active_record'
====> Doorkeeper version: 5.6.6
====> Rails version: 7.0.5
====> Ruby version: 3.2.2 on x86_64-darwin22

Randomized with seed 9337
..................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 9.47 seconds (files took 4.94 seconds to load)
1186 examples, 0 failures

Randomized with seed 9337
```
